### PR TITLE
Fix spelling error in pod

### DIFF
--- a/lib/MARC/Spec/Parser.pm
+++ b/lib/MARC/Spec/Parser.pm
@@ -327,7 +327,7 @@ MARCspec as string.
 
 =head2 spec
 
-Obligatory. The parameter string the MARC::Spec::Parser was instanciated with.
+Obligatory. The parameter string the MARC::Spec::Parser was instantiated with.
 
 =head2 marcspec
 


### PR DESCRIPTION
lintian reported spelling-error-in-manpage
usr/share/man/man3/MARC::Spec::Parser.3pm.gz instanciated instantiated